### PR TITLE
fixed: support getResponseHeader not case insensitive

### DIFF
--- a/packages/miniprogram-render/src/bom/xml-http-request.js
+++ b/packages/miniprogram-render/src/bom/xml-http-request.js
@@ -248,7 +248,8 @@ class XMLHttpRequest extends EventTarget {
     getResponseHeader(name) {
         if (this.$_readyState === XMLHttpRequest.UNSENT || this.$_readyState === XMLHttpRequest.OPENED || !this.$_resHeader) return null
 
-        const value = this.$_resHeader[name]
+        const key = Object.keys(this.$_resHeader).find(k => k.toLowerCase() === name.toLowerCase())
+        const value = key ? this.$_resHeader[key] : null
 
         return typeof value === 'string' ? value : null
     }


### PR DESCRIPTION
headerName  is not case-sensitive.

https://developer.mozilla.org/zh-CN/docs/Web/API/XMLHttpRequest/getResponseHeader
