### PR TITLE
feature: support some inline css

### DIFF
--- a/packages/miniprogram-render/src/node/style-list.js
+++ b/packages/miniprogram-render/src/node/style-list.js
@@ -24,5 +24,7 @@ module.exports = [
     'visibility', 'opacity', 'zIndex', 'zoom', 'overflow', 'overflowX', 'overflowY',
     'boxShadow', 'boxSizing', 'content', 'cursor', 'direction', 'listStyle', 'objectFit', 'pointerEvents', 'resize', 'verticalAlign', 'willChange', 'clip', 'clipPath', 'fill',
 
-    'touchAction', 'WebkitAppearance'
+    'touchAction', 'WebkitAppearance',
+
+    'WebkitLineClamp', 'WebkitBoxOrient', 'WebkitMask', 'WebkitMaskSize'
 ]

--- a/packages/miniprogram-render/src/node/style.js
+++ b/packages/miniprogram-render/src/node/style.js
@@ -134,7 +134,10 @@ class Style {
     set cssText(styleText) {
         if (typeof styleText !== 'string') return
 
-        styleText = styleText.replace(/"/g, '\'')
+        // 当既有单引号又有双引号时不进行替换
+        if (!(styleText.indexOf('\"') > -1 && styleText.indexOf('\'') > -1)) {
+            styleText = styleText.replace(/"/g, '\'')
+        }
 
         // 解析样式
         const rules = parse(styleText)


### PR DESCRIPTION
1. 支持一些内联样式，包括：
-webkit-line-clamp
-webkit-box-orient
-webkit-mask
-webkit-mask-size
2. 当设置内联样式时，如果属性值既有单引号又有双引号，就不把引号全部替换为单引号，例如：
WebkitMask: url("data:image/svg+xml,%3Csvg width='32' height='32' viewBox='0 0 32 32' xmlns='http://www.w3.org/2000/svg'%3E%3Ctitle%3Eon_dark%3C/title%3E%3Cg fill='none' fill-rule='evenodd'%3E%3Ccircle stroke-opacity='.254' stroke='%23FFF' stroke-width='.5' cx='16' cy='16' r='15.75'/%3E%3Cpath fill='none' d='M4 4h24v24H4z' fill-opacity='0'/%3E%3Cpath fill='%23FFF' d='M15 20.5h2v3h-2z'/%3E%3Cpath d='M20.498 23.09V16.81h3.115c.031 0 .065-.035.065-.088a.1.1 0 0 0-.027-.07l-7.613-7.81c-.023-.025-.053-.025-.076 0l-7.613 7.81a.105.105 0 0 0 0 .14.054.054 0 0 0 .038.018h3.115v6.281c0 .053.034.088.064.088h8.868c.03 0 .064-.035.064-.088z' stroke='%23FFF' stroke-width='1.644'/%3E%3C/g%3E%3C/svg%3E") no-repeat 50% 50%;